### PR TITLE
Initial SymbiFlow arch interchange export

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "database"]
 	path = database
 	url = https://github.com/gatecat/prjoxide-db
+[submodule "3rdparty/fpga-interchange-schema"]
+	path = 3rdparty/fpga-interchange-schema
+	url = https://github.com/SymbiFlow/fpga-interchange-schema

--- a/libprjoxide/prjoxide/Cargo.toml
+++ b/libprjoxide/prjoxide/Cargo.toml
@@ -3,6 +3,7 @@ name = "prjoxide"
 version = "0.1.0"
 authors = ["gatecat <gatecat@ds0.me>"]
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 regex = "1"
@@ -17,6 +18,10 @@ rug = "1.6.0"
 log = "0.4.11"
 clap = "3.0.0-beta.2"
 include_dir = "0.6.0"
+capnp = "0.14"
+
+[build-dependencies]
+capnpc = "0.14"
 
 [lib]
 name = "prjoxide"

--- a/libprjoxide/prjoxide/Cargo.toml
+++ b/libprjoxide/prjoxide/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["gatecat <gatecat@ds0.me>"]
 edition = "2018"
 build = "build.rs"
 
+[features]
+default = []
+interchange = ["capnp", "flate2", "capnpc"]
+
 [dependencies]
 regex = "1"
 serde = { version = "1", features = ["derive"] }
@@ -18,11 +22,11 @@ rug = "1.6.0"
 log = "0.4.11"
 clap = "3.0.0-beta.2"
 include_dir = "0.6.0"
-capnp = "0.14"
-flate2 = "1.0"
+capnp = {version = "0.14", optional = true }
+flate2 = {version = "1.0", optional = true }
 
 [build-dependencies]
-capnpc = "0.14"
+capnpc = {version = "0.14", optional = true }
 
 [lib]
 name = "prjoxide"

--- a/libprjoxide/prjoxide/Cargo.toml
+++ b/libprjoxide/prjoxide/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4.11"
 clap = "3.0.0-beta.2"
 include_dir = "0.6.0"
 capnp = "0.14"
+flate2 = "1.0"
 
 [build-dependencies]
 capnpc = "0.14"

--- a/libprjoxide/prjoxide/build.rs
+++ b/libprjoxide/prjoxide/build.rs
@@ -1,0 +1,17 @@
+fn main() {
+    capnpc::CompilerCommand::new()
+        .default_parent_module(vec!["schema".into()])
+        .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
+        .file("../../3rdparty/fpga-interchange-schema/interchange/References.capnp")
+        .run().expect("schema compiler command");
+    capnpc::CompilerCommand::new()
+        .default_parent_module(vec!["schema".into()])
+        .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
+        .file("../../3rdparty/fpga-interchange-schema/interchange/LogicalNetlist.capnp")
+        .run().expect("schema compiler command");
+    capnpc::CompilerCommand::new()
+        .default_parent_module(vec!["schema".into()])
+        .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
+        .file("../../3rdparty/fpga-interchange-schema/interchange/DeviceResources.capnp")
+        .run().expect("schema compiler command");
+}

--- a/libprjoxide/prjoxide/build.rs
+++ b/libprjoxide/prjoxide/build.rs
@@ -1,17 +1,19 @@
 fn main() {
-    capnpc::CompilerCommand::new()
-        .default_parent_module(vec!["schema".into()])
-        .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
-        .file("../../3rdparty/fpga-interchange-schema/interchange/References.capnp")
-        .run().expect("schema compiler command");
-    capnpc::CompilerCommand::new()
-        .default_parent_module(vec!["schema".into()])
-        .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
-        .file("../../3rdparty/fpga-interchange-schema/interchange/LogicalNetlist.capnp")
-        .run().expect("schema compiler command");
-    capnpc::CompilerCommand::new()
-        .default_parent_module(vec!["schema".into()])
-        .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
-        .file("../../3rdparty/fpga-interchange-schema/interchange/DeviceResources.capnp")
-        .run().expect("schema compiler command");
+    #[cfg(feature = "interchange")] {
+        capnpc::CompilerCommand::new()
+            .default_parent_module(vec!["schema".into()])
+            .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
+            .file("../../3rdparty/fpga-interchange-schema/interchange/References.capnp")
+            .run().expect("schema compiler command");
+        capnpc::CompilerCommand::new()
+            .default_parent_module(vec!["schema".into()])
+            .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
+            .file("../../3rdparty/fpga-interchange-schema/interchange/LogicalNetlist.capnp")
+            .run().expect("schema compiler command");
+        capnpc::CompilerCommand::new()
+            .default_parent_module(vec!["schema".into()])
+            .src_prefix("../../3rdparty/fpga-interchange-schema/interchange/")
+            .file("../../3rdparty/fpga-interchange-schema/interchange/DeviceResources.capnp")
+            .run().expect("schema compiler command");
+    }
 }

--- a/libprjoxide/prjoxide/src/bba/idstring.rs
+++ b/libprjoxide/prjoxide/src/bba/idstring.rs
@@ -78,4 +78,11 @@ impl IdStringDB {
     pub fn str(&self, index: IdString) -> &str {
         &self.strings[index.0]
     }
+
+    pub fn len(&self) -> usize {
+        self.strings.len()
+    }
+    pub fn idx_str(&self, index: usize) -> &str {
+        &self.strings[index]
+    }
 }

--- a/libprjoxide/prjoxide/src/bin/prjoxide.rs
+++ b/libprjoxide/prjoxide/src/bin/prjoxide.rs
@@ -35,6 +35,8 @@ enum SubCommand {
     Unpack(Unpack),
     #[clap(about = "export a BBA file for the nextpnr build")]
     BBAExport(BBAExport),
+    #[clap(about = "export a FPGA interchange file (not yet implemented)")]
+    InterchangeExport(InterchangeExport),
 }
 
 #[derive(Clap)]
@@ -179,6 +181,24 @@ impl BBAExport {
     }
 }
 
+#[derive(Clap)]
+struct InterchangeExport {
+    #[clap(about = "device name")]
+    device: String,
+    #[clap(about = "path to output interchange file")]
+    interchange: String,
+}
+
+impl InterchangeExport {
+    pub fn run(&self) -> Result<()> {
+        let mut ids = IdStringDB::new();
+        let mut db = Database::new_builtin(DATABASE_DIR);
+        let c = Chip::from_name(&mut db, &self.device);
+        let g = prjoxide::interchange_gen::routing_graph::GraphBuilder::run(&mut ids, &c, &mut db);
+        unimplemented!();
+    }
+}
+
 fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
     match opts.subcmd {
@@ -189,6 +209,9 @@ fn main() -> Result<()> {
             t.run()
         }
         SubCommand::BBAExport(t) => {
+            t.run()
+        }
+        SubCommand::InterchangeExport(t) => {
             t.run()
         }
     }

--- a/libprjoxide/prjoxide/src/bin/prjoxide.rs
+++ b/libprjoxide/prjoxide/src/bin/prjoxide.rs
@@ -195,7 +195,8 @@ impl InterchangeExport {
         let mut db = Database::new_builtin(DATABASE_DIR);
         let c = Chip::from_name(&mut db, &self.device);
         let g = prjoxide::interchange_gen::routing_graph::GraphBuilder::run(&mut ids, &c, &mut db);
-        unimplemented!();
+        prjoxide::interchange_gen::writer::write(&c, &mut db, &mut ids, &g, &self.interchange).unwrap();
+        Ok(())
     }
 }
 

--- a/libprjoxide/prjoxide/src/bin/prjoxide.rs
+++ b/libprjoxide/prjoxide/src/bin/prjoxide.rs
@@ -35,6 +35,7 @@ enum SubCommand {
     Unpack(Unpack),
     #[clap(about = "export a BBA file for the nextpnr build")]
     BBAExport(BBAExport),
+    #[cfg(feature = "interchange")]
     #[clap(about = "export a FPGA interchange file (not yet implemented)")]
     InterchangeExport(InterchangeExport),
 }
@@ -182,6 +183,7 @@ impl BBAExport {
 }
 
 #[derive(Clap)]
+#[cfg(feature = "interchange")]
 struct InterchangeExport {
     #[clap(about = "device name")]
     device: String,
@@ -189,6 +191,7 @@ struct InterchangeExport {
     interchange: String,
 }
 
+#[cfg(feature = "interchange")]
 impl InterchangeExport {
     pub fn run(&self) -> Result<()> {
         let mut ids = IdStringDB::new();
@@ -212,6 +215,7 @@ fn main() -> Result<()> {
         SubCommand::BBAExport(t) => {
             t.run()
         }
+        #[cfg(feature = "interchange")]
         SubCommand::InterchangeExport(t) => {
             t.run()
         }

--- a/libprjoxide/prjoxide/src/interchange_gen.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen.rs
@@ -1,0 +1,1 @@
+use crate::schema::DeviceResources_capnp::*;

--- a/libprjoxide/prjoxide/src/interchange_gen.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen.rs
@@ -1,1 +1,0 @@
-use crate::schema::DeviceResources_capnp::*;

--- a/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
@@ -1,3 +1,5 @@
+use crate::chip::Chip;
+use crate::database::Database;
 use std::collections::HashMap;
 
 use crate::bba::idstring::*;
@@ -7,49 +9,134 @@ use crate::bba::idstring::*;
 // this is not the same as a database tile type; because the Oxide graph can have
 // more than one tile at a grid location whereas the interchange grid is one tile
 // per location
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+struct TileTypeKey {
+    pub tile_types: Vec<String>,
+}
+impl TileTypeKey {
+    pub fn new() -> TileTypeKey {
+        TileTypeKey { tile_types: Vec::new() }
+    }
+}
+
 struct IcTileType {
-	type_idx: u32,
-	tile_types: Vec<String>,
-	wires: Vec<IcWire>,
-	pips: Vec<IcPip>,
-	wires_by_name: HashMap<IdString, usize>,
-	// TODO: constants, sites, etc
+    key: TileTypeKey,
+    type_idx: u32,
+    wires: Vec<IcWire>,
+    pips: Vec<IcPip>,
+    wires_by_name: HashMap<IdString, usize>,
+    // TODO: constants, sites, etc
+}
+
+impl IcTileType {
+    pub fn new(key: TileTypeKey, idx: u32) -> IcTileType {
+        IcTileType {
+            key: key,
+            type_idx: idx,
+            wires: Vec::new(),
+            pips: Vec::new(),
+            wires_by_name: HashMap::new(),
+        }
+    }
 }
 
 struct IcWire {
-	name: IdString,
-	pips_uphill: Vec<u32>,
-	pips_downhill: Vec<u32>,
+    name: IdString,
+    pips_uphill: Vec<u32>,
+    pips_downhill: Vec<u32>,
 }
 
 struct IcPip {
-	name: IdString,
-	from_wire: u32,
-	to_wire: u32,
+    name: IdString,
+    from_wire: u32,
+    to_wire: u32,
 }
 
 // A tile instance
 struct IcTileInst {
-	type_idx: u32,
-	// mapping between wires and nodes
-	wire_to_node: Vec<u32>,
+    type_idx: u32,
+    // mapping between wires and nodes
+    wire_to_node: Vec<u32>,
+}
+
+impl IcTileInst {
+    pub fn new() -> IcTileInst {
+        IcTileInst {
+            type_idx: 0,
+            wire_to_node: Vec::new(),
+        }
+    }
 }
 
 // A reference to a tile wire
 struct IcWireRef {
-	tile_idx: u32,
-	wire_idx: u32,
+    tile_idx: u32,
+    wire_idx: u32,
 }
 
 // A node instance
 struct IcNode {
-	// list of tile wires in the node
-	wires: Vec<IcWireRef>,
+    // list of tile wires in the node
+    wires: Vec<IcWireRef>,
+}
+
+impl IcNode {
+    pub fn new() -> IcNode {
+        IcNode {
+            wires: Vec::new(),
+        }
+    }
 }
 
 // The overall routing resource graph
 struct IcGraph {
-	tile_types: Vec<IcTileType>,
-	tiles: Vec<IcTileInst>,
-	nodes: Vec<IcNode>,
+    tile_types: Vec<IcTileType>,
+    tiles: Vec<IcTileInst>,
+    nodes: Vec<IcNode>,
+    width: u32,
+    height: u32,
+}
+
+impl IcGraph {
+    pub fn new(width: u32, height: u32) -> IcGraph {
+        IcGraph {
+            tile_types: Vec::new(),
+            tiles: (0..width*height).map(|_| IcTileInst::new()).collect(),
+            nodes: Vec::new(),
+            width: width,
+            height: height
+        }
+    }
+}
+
+struct GraphBuilder<'a> {
+    g: IcGraph,
+    ids: &'a mut IdStringDB,
+    chip: &'a Chip,
+    db: &'a mut Database,
+    tiletypes_by_xy: HashMap<(u32, u32), TileTypeKey>,
+}
+
+
+impl <'a> GraphBuilder<'a> {
+    pub fn new(ids: &'a mut IdStringDB, chip: &'a Chip, db: &'a mut Database) -> GraphBuilder<'a> {
+        let mut width = 0;
+        let mut height = 0;
+        let mut tiletypes_by_xy = HashMap::new();
+        for t in chip.tiles.iter() {
+            tiletypes_by_xy.entry((t.x, t.y)).or_insert(TileTypeKey::new()).tile_types.push(t.tiletype.to_string());
+            width = std::cmp::max(width, t.x + 1);
+            height = std::cmp::max(height, t.y + 1);
+        }
+
+        GraphBuilder {
+            g: IcGraph::new(width, height),
+            ids: ids,
+            chip: chip,
+            db: db,
+            tiletypes_by_xy: tiletypes_by_xy,
+        }
+    }
+
 }

--- a/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
@@ -23,9 +23,9 @@ impl TileTypeKey {
 }
 
 pub struct IcTileType {
-    key: TileTypeKey,
-    wires: IndexedMap<IdString, IcWire>,
-    pips: Vec<IcPip>,
+    pub key: TileTypeKey,
+    pub wires: IndexedMap<IdString, IcWire>,
+    pub pips: Vec<IcPip>,
     // TODO: constants, sites, etc
 }
 
@@ -51,7 +51,7 @@ impl IcTileType {
 }
 
 pub struct IcWire {
-    name: IdString,
+    pub name: IdString,
 }
 
 impl IcWire {
@@ -63,22 +63,24 @@ impl IcWire {
 }
 
 pub struct IcPip {
-    src_wire: usize,
-    dst_wire: usize,
+    pub src_wire: usize,
+    pub dst_wire: usize,
 }
 
 // A tile instance
 pub struct IcTileInst {
-    x: u32,
-    y: u32,
-    type_idx: usize,
+    pub name: IdString,
+    pub x: u32,
+    pub y: u32,
+    pub type_idx: usize,
     // mapping between wires and nodes
     wire_to_node: HashMap<usize, usize>,
 }
 
 impl IcTileInst {
-    pub fn new(x: u32, y: u32) -> IcTileInst {
+    pub fn new(ids: &mut IdStringDB, x: u32, y: u32) -> IcTileInst {
         IcTileInst {
+            name: ids.id(&format!("R{}C{}", y, x)),
             x: x,
             y: y,
             type_idx: 0,
@@ -90,15 +92,15 @@ impl IcTileInst {
 // A reference to a tile wire
 #[derive(Clone, Hash, Eq, PartialEq)]
 pub struct IcWireRef {
-    tile_idx: usize,
-    wire_idx: usize,
+    pub tile_idx: usize,
+    pub wire_idx: usize,
 }
 
 // A node instance
 pub struct IcNode {
     // list of tile wires in the node
-    wires: HashSet<IcWireRef>,
-    root_wire: IcWireRef,
+    pub wires: HashSet<IcWireRef>,
+    pub root_wire: IcWireRef,
 }
 
 impl IcNode {
@@ -112,18 +114,18 @@ impl IcNode {
 
 // The overall routing resource graph
 pub struct IcGraph {
-    tile_types: IndexedMap<TileTypeKey, IcTileType>,
-    tiles: Vec<IcTileInst>,
-    nodes: Vec<IcNode>,
-    width: u32,
-    height: u32,
+    pub tile_types: IndexedMap<TileTypeKey, IcTileType>,
+    pub tiles: Vec<IcTileInst>,
+    pub nodes: Vec<IcNode>,
+    pub width: u32,
+    pub height: u32,
 }
 
 impl IcGraph {
-    pub fn new(width: u32, height: u32) -> IcGraph {
+    pub fn new(ids: &mut IdStringDB, width: u32, height: u32) -> IcGraph {
         IcGraph {
             tile_types: IndexedMap::new(),
-            tiles: (0..width*height).map(|i| IcTileInst::new(i%width, i/width)).collect(),
+            tiles: (0..width*height).map(|i| IcTileInst::new(ids, i%width, i/width)).collect(),
             nodes: Vec::new(),
             width: width,
             height: height
@@ -184,7 +186,7 @@ impl <'a> GraphBuilder<'a> {
         let orig_tts = TileTypes::new(db, ids, &chip.family, &[&chip.device]);
 
         GraphBuilder {
-            g: IcGraph::new(width, height),
+            g: IcGraph::new(ids, width, height),
             ids: ids,
             chip: chip,
             db: db,

--- a/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+
+use crate::bba::idstring::*;
+
+
+// A tile type from the interchange format perspective
+// this is not the same as a database tile type; because the Oxide graph can have
+// more than one tile at a grid location whereas the interchange grid is one tile
+// per location
+struct IcTileType {
+	type_idx: u32,
+	tile_types: Vec<String>,
+	wires: Vec<IcWire>,
+	pips: Vec<IcPip>,
+	wires_by_name: HashMap<IdString, usize>,
+	// TODO: constants, sites, etc
+}
+
+struct IcWire {
+	name: IdString,
+	pips_uphill: Vec<u32>,
+	pips_downhill: Vec<u32>,
+}
+
+struct IcPip {
+	name: IdString,
+	from_wire: u32,
+	to_wire: u32,
+}
+
+// A tile instance
+struct IcTileInst {
+	type_idx: u32,
+	// mapping between wires and nodes
+	wire_to_node: Vec<u32>,
+}
+
+// A reference to a tile wire
+struct IcWireRef {
+	tile_idx: u32,
+	wire_idx: u32,
+}
+
+// A node instance
+struct IcNode {
+	// list of tile wires in the node
+	wires: Vec<IcWireRef>,
+}
+
+// The overall routing resource graph
+struct IcGraph {
+	tile_types: Vec<IcTileType>,
+	tiles: Vec<IcTileInst>,
+	nodes: Vec<IcNode>,
+}

--- a/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "interchange")]
+
 use crate::chip::Chip;
 use crate::database::Database;
 use std::collections::{HashSet, HashMap};

--- a/libprjoxide/prjoxide/src/interchange_gen/writer.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/writer.rs
@@ -100,6 +100,11 @@ pub fn write(c: &Chip, _db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph
             c2b.reborrow().get(1).set_cell(ids.id("VHI").val().try_into().unwrap());
         }
         {
+            let mut packages = dev.reborrow().init_packages(1);
+            packages.reborrow().get(0).set_name(ids.id("QFN72").val().try_into().unwrap());
+            // TODO: all packages and pin map
+        }
+        {
             let mut strs = dev.init_str_list(ids.len().try_into().unwrap());
             for i in 0..ids.len() {
                 strs.set(i.try_into().unwrap(), ids.idx_str(i));

--- a/libprjoxide/prjoxide/src/interchange_gen/writer.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/writer.rs
@@ -1,0 +1,81 @@
+use crate::interchange_gen::routing_graph::*;
+use crate::schema::*;
+use crate::chip::Chip;
+use crate::database::Database;
+use crate::bba::idstring::*;
+
+use std::convert::TryInto;
+
+pub fn write(c: &Chip, db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph, filename: &str) -> ::capnp::Result<()> {
+    let mut m = ::capnp::message::Builder::new_default();
+    {
+        let mut dev = m.init_root::<DeviceResources_capnp::device::Builder>();
+        dev.set_name(&c.device);
+        {
+            let mut tiletypes = dev.reborrow().init_tile_type_list(graph.tile_types.len().try_into().unwrap());
+            for (i, (_, data)) in graph.tile_types.iter().enumerate() {
+                let mut tt = tiletypes.reborrow().get(i.try_into().unwrap());
+                // TODO: form a nice name from the constituent tile types
+                tt.set_name(ids.id(&format!("tiletype_{}", i)).val().try_into().unwrap());
+                {
+                    let mut wires = tt.reborrow().init_wires(data.wires.len().try_into().unwrap());
+                    for (j, (_, wire_data)) in data.wires.iter().enumerate() {
+                        wires.set(j.try_into().unwrap(),  wire_data.name.val().try_into().unwrap());
+                    }
+                }
+                {
+                    let mut pips = tt.reborrow().init_pips(data.pips.len().try_into().unwrap());
+                    for (j, pip_data) in data.pips.iter().enumerate() {
+                        let mut p = pips.reborrow().get(j.try_into().unwrap());
+                        p.set_wire0(pip_data.src_wire.try_into().unwrap());
+                        p.set_wire1(pip_data.dst_wire.try_into().unwrap());
+                        p.set_directional(true);
+                        p.set_buffered20(true);
+                        p.set_buffered21(false);
+                        p.set_conventional(());
+                    }
+                }
+                // TODO: constant sources
+            }
+        }
+        let mut wire_list = Vec::new();
+        {
+            // this wire_list is the list of wires as we create nodes, to be output as dev.wires later
+            let mut nodes = dev.reborrow().init_nodes(graph.nodes.len().try_into().unwrap());
+            for (i, node_data) in graph.nodes.iter().enumerate() {
+                let n = nodes.reborrow().get(i.try_into().unwrap());
+                let mut node_wires = n.init_wires(node_data.wires.len().try_into().unwrap());
+                // write root wire
+                {
+                    node_wires.set(0, wire_list.len().try_into().unwrap());
+                    wire_list.push((node_data.root_wire.tile_idx, node_data.root_wire.wire_idx));
+                }
+                let mut node_wire_idx = 1;
+                // write non-root wires
+                for wire in node_data.wires.iter().filter(|w| **w != node_data.root_wire) {
+                    node_wires.set(node_wire_idx, wire_list.len().try_into().unwrap());
+                    wire_list.push((wire.tile_idx, wire.wire_idx));
+                    node_wire_idx += 1;
+                }
+            }
+        }
+        {
+            let mut wires = dev.reborrow().init_wires(wire_list.len().try_into().unwrap());
+            for (i, (tile_idx, wire_idx)) in wire_list.iter().enumerate() {
+                let mut w = wires.reborrow().get(i.try_into().unwrap());
+                // TODO: should IcGraph use IdStrings to better match what we write out?
+                let tile = &graph.tiles[*tile_idx];
+                w.set_tile(tile.name.val().try_into().unwrap());
+                w.set_wire(graph.tile_types.value(tile.type_idx).wires.value(*wire_idx).name.val().try_into().unwrap());
+            }
+        }
+        {
+            let mut strs = dev.init_str_list(ids.len().try_into().unwrap());
+            for i in 0..ids.len() {
+                strs.set(i.try_into().unwrap(), ids.idx_str(i));
+            }
+        }
+    }
+    ::capnp::serialize_packed::write_message(std::fs::File::create(filename)?, &m)?;
+    Ok(())
+}

--- a/libprjoxide/prjoxide/src/interchange_gen/writer.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/writer.rs
@@ -73,6 +73,28 @@ pub fn write(c: &Chip, _db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph
             }
         }
         {
+            let mut tiles = dev.reborrow().init_tile_list(graph.tiles.len().try_into().unwrap());
+            for (i, tile_data) in graph.tiles.iter().enumerate() {
+                let mut t = tiles.reborrow().get(i.try_into().unwrap());
+                t.set_name(tile_data.name.val().try_into().unwrap());
+                t.set_type(tile_data.type_idx.try_into().unwrap());
+                t.set_row(tile_data.y.try_into().unwrap());
+                t.set_col(tile_data.x.try_into().unwrap());
+            }
+        }
+        {
+            let mut constants = dev.reborrow().init_constants();
+            constants.set_gnd_cell_type(ids.id("VLO").val().try_into().unwrap());
+            constants.set_gnd_cell_pin(ids.id("Z").val().try_into().unwrap());
+            constants.set_vcc_cell_type(ids.id("VHI").val().try_into().unwrap());
+            constants.set_vcc_cell_pin(ids.id("Z").val().try_into().unwrap());
+        }
+        {
+            let mut c2b = dev.reborrow().init_cell_bel_map(2);
+            c2b.reborrow().get(0).set_cell(ids.id("VLO").val().try_into().unwrap());
+            c2b.reborrow().get(1).set_cell(ids.id("VHI").val().try_into().unwrap());
+        }
+        {
             let mut strs = dev.init_str_list(ids.len().try_into().unwrap());
             for i in 0..ids.len() {
                 strs.set(i.try_into().unwrap(), ids.idx_str(i));

--- a/libprjoxide/prjoxide/src/interchange_gen/writer.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/writer.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "interchange")]
+
 use crate::interchange_gen::routing_graph::*;
 use crate::schema::*;
 use crate::chip::Chip;

--- a/libprjoxide/prjoxide/src/interchange_gen/writer.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/writer.rs
@@ -6,7 +6,10 @@ use crate::bba::idstring::*;
 
 use std::convert::TryInto;
 
-pub fn write(c: &Chip, db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph, filename: &str) -> ::capnp::Result<()> {
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+pub fn write(c: &Chip, _db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph, filename: &str) -> ::capnp::Result<()> {
     let mut m = ::capnp::message::Builder::new_default();
     {
         let mut dev = m.init_root::<DeviceResources_capnp::device::Builder>();
@@ -76,6 +79,8 @@ pub fn write(c: &Chip, db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph,
             }
         }
     }
-    ::capnp::serialize_packed::write_message(std::fs::File::create(filename)?, &m)?;
+    let mut e = GzEncoder::new(std::fs::File::create(filename)?, Compression::default());
+    ::capnp::serialize::write_message(&mut e, &m)?;
+    e.finish()?;
     Ok(())
 }

--- a/libprjoxide/prjoxide/src/interchange_gen/writer.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/writer.rs
@@ -19,7 +19,12 @@ pub fn write(c: &Chip, _db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph
             for (i, (_, data)) in graph.tile_types.iter().enumerate() {
                 let mut tt = tiletypes.reborrow().get(i.try_into().unwrap());
                 // TODO: form a nice name from the constituent tile types
-                tt.set_name(ids.id(&format!("tiletype_{}", i)).val().try_into().unwrap());
+                // TODO: remove the NULL hack
+                if i == graph.tiles[0].type_idx {
+                    tt.set_name(ids.id("NULL").val().try_into().unwrap());
+                } else {
+                    tt.set_name(ids.id(&format!("tiletype_{}", i)).val().try_into().unwrap());
+                }
                 {
                     let mut wires = tt.reborrow().init_wires(data.wires.len().try_into().unwrap());
                     for (j, (_, wire_data)) in data.wires.iter().enumerate() {

--- a/libprjoxide/prjoxide/src/lib.rs
+++ b/libprjoxide/prjoxide/src/lib.rs
@@ -26,5 +26,7 @@ pub mod nodecheck;
 pub mod wires;
 pub mod pip_classes;
 pub mod sites;
-pub mod interchange_gen;
+pub mod interchange_gen {
+	mod routing_graph;
+}
 mod schema;

--- a/libprjoxide/prjoxide/src/lib.rs
+++ b/libprjoxide/prjoxide/src/lib.rs
@@ -26,3 +26,5 @@ pub mod nodecheck;
 pub mod wires;
 pub mod pip_classes;
 pub mod sites;
+pub mod interchange_gen;
+mod schema;

--- a/libprjoxide/prjoxide/src/lib.rs
+++ b/libprjoxide/prjoxide/src/lib.rs
@@ -27,6 +27,6 @@ pub mod wires;
 pub mod pip_classes;
 pub mod sites;
 pub mod interchange_gen {
-	mod routing_graph;
+	pub mod routing_graph;
 }
 mod schema;

--- a/libprjoxide/prjoxide/src/lib.rs
+++ b/libprjoxide/prjoxide/src/lib.rs
@@ -28,5 +28,6 @@ pub mod pip_classes;
 pub mod sites;
 pub mod interchange_gen {
 	pub mod routing_graph;
+    pub mod writer;
 }
 mod schema;

--- a/libprjoxide/prjoxide/src/schema.rs
+++ b/libprjoxide/prjoxide/src/schema.rs
@@ -1,4 +1,6 @@
 #![allow(warnings, unused)]
+#![cfg(feature = "interchange")]
+
 pub mod References_capnp {
     include!(concat!(env!("OUT_DIR"), "/References_capnp.rs"));
 }

--- a/libprjoxide/prjoxide/src/schema.rs
+++ b/libprjoxide/prjoxide/src/schema.rs
@@ -1,0 +1,10 @@
+#![allow(warnings, unused)]
+pub mod References_capnp {
+    include!(concat!(env!("OUT_DIR"), "/References_capnp.rs"));
+}
+pub mod LogicalNetlist_capnp {
+    include!(concat!(env!("OUT_DIR"), "/LogicalNetlist_capnp.rs"));
+}
+pub mod DeviceResources_capnp {
+    include!(concat!(env!("OUT_DIR"), "/DeviceResources_capnp.rs"));
+}


### PR DESCRIPTION
This exports a basic routing graph, enough to generate a nextpnr chipdb and pass the architecture check. Missing:

 - sites and bels, so you can't build anything useful
 - constants
 - global network
 - constraints
 - package pins

Generating the chipdb also requires SymbiFlow/python-fpga-interchange#33

Also, before anything is merged this needs to be made optional using Rust's conditional feature stuff to avoid extra dependencies and build time for those that don't need it (which is most people for the time being). There is probably some tidying up of the interchange-friendly routing graph generation to be done too.