### PR TITLE
Make cross compile possible

### DIFF
--- a/libprjoxide/prjoxide/Cargo.toml
+++ b/libprjoxide/prjoxide/Cargo.toml
@@ -24,6 +24,7 @@ clap = "3.0.0-beta.2"
 include_dir = "0.6.0"
 capnp = {version = "0.14", optional = true }
 flate2 = {version = "1.0", optional = true }
+gmp-mpfr-sys = { version="1.4.3", features=["force-cross"] }
 
 [build-dependencies]
 capnpc = {version = "0.14", optional = true }


### PR DESCRIPTION
So far can confirm that with this change ARM (armhf) and ARM64 (aarch64) builds are compiling fine.