### PR TITLE
interchange: Add LUT definitions

### DIFF
--- a/libprjoxide/prjoxide/src/bba/idxset.rs
+++ b/libprjoxide/prjoxide/src/bba/idxset.rs
@@ -78,6 +78,9 @@ impl<Key: Eq + Hash + Clone, Value> IndexedMap<Key, Value> {
     pub fn value(&self, index: usize) -> &Value {
         &self.data[index].1
     }
+    pub fn value_by_key(&self, key: &Key) -> &Value {
+        &self.data[self.get_index(key).unwrap()].1
+    }
 
     pub fn value_mut(&mut self, index: usize) -> &mut Value {
         &mut self.data[index].1

--- a/libprjoxide/prjoxide/src/interchange_gen/bel_pin_map.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/bel_pin_map.rs
@@ -39,11 +39,22 @@ const FD1P3JX_PIN_MAP : &[(&str, &str)] = &[
     ("Q", "Q"),
 ];
 
+const IB_PIN_MAP : &[(&str, &str)] = &[
+    ("I", "B"),
+    ("O", "O"),
+];
+
+const OB_PIN_MAP : &[(&str, &str)] = &[
+    ("I", "I"),
+    ("O", "B"),
+];
 // TODO: add back DFFs once we have some constraints set up
 
 const BEL_CELL_TYPES : &[(&str, &[&str])] = &[
     ("OXIDE_COMB", &["LUT4"]),
-//    ("OXIDE_FF", &["FD1P3BX", "FD1P3DX", "FD1P3IX", "FD1P3JX"]),
+    ("OXIDE_FF", &["FD1P3BX", "FD1P3DX", "FD1P3IX", "FD1P3JX"]),
+    ("SEIO33_CORE", &["IB", "OB"]),
+    ("SEIO18_CORE", &["IB", "OB"]),
 ];
 
 fn conv_map(map: &[(&str, &str)]) -> Vec<(String, String)> {
@@ -57,10 +68,13 @@ fn get_map_for_cell_bel(cell_type: &str, _bel: &SiteBel) -> Vec<(String, String)
         "FD1P3DX" => conv_map(FD1P3DX_PIN_MAP),
         "FD1P3IX" => conv_map(FD1P3IX_PIN_MAP),
         "FD1P3JX" => conv_map(FD1P3JX_PIN_MAP),
+        "IB" => conv_map(IB_PIN_MAP),
+        "OB" => conv_map(OB_PIN_MAP),
         _ => unimplemented!(),
     }
 }
 
+#[derive(Clone)]
 pub struct PinMap {
     pub cell_type: String,
     pub bels: Vec<String>,

--- a/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
@@ -245,6 +245,14 @@ impl <'a> GraphBuilder<'a> {
                     }
                 }
             }
+            // Create pseudo-ground drivers for LUT outputs
+            if lt.site_types.iter().find(|s| s.site_type == "PLC").is_some() {
+                let gnd_wire = self.ids.id("G:GND");
+                lt.wire(gnd_wire);
+                for i in 0..8 {
+                    lt.add_pip(gnd_wire, self.ids.id(&format!("JF{}", i)));
+                }
+            }
         }
     }
     // Convert a neighbour to a coordinate

--- a/libprjoxide/prjoxide/src/interchange_gen/writer.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/writer.rs
@@ -245,30 +245,6 @@ pub fn write(c: &Chip, _db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph
                 }
             }
         }
-        /* {
-            let mut constraints = dev.reborrow().init_constraints();
-            {
-                let mut cc = constraints.reborrow().init_cell_constraints(cell2site_bel.len().try_into().unwrap());
-                for (i, (cell_type, (cell_sites, cell_bels))) in cell2site_bel.iter().enumerate() {
-                    let mut constr = cc.reborrow().get(i.try_into().unwrap());
-                    constr.set_cell(cell_type);
-                    let mut constr_locs = constr.init_locations(1).get(0);
-                    {
-                        let mut constr_sites = constr_locs.reborrow().init_site_types(cell_sites.len().try_into().unwrap());
-                        for (j, s) in cell_sites.iter().enumerate() {
-                            constr_sites.set(j.try_into().unwrap(), s);
-                        }
-                    }
-                    {
-                        let mut constr_bels = constr_locs.reborrow().init_bel().init_bels(cell_bels.len().try_into().unwrap());
-                        for (j, b) in cell_bels.iter().enumerate() {
-                            constr_bels.set(j.try_into().unwrap(), b);
-                        }
-                    }
-                    constr_locs.reborrow().init_implies(0);
-                }
-            }
-        } */
         {
             let mut packages = dev.reborrow().init_packages(1);
             packages.reborrow().get(0).set_name(ids.id("QFN72").val().try_into().unwrap());


### PR DESCRIPTION
On top of #5, and currently hitting some problems in the nextpnr LUT handling code, probably due to the Nexus not having smaller-than-LUT4 primitives where inputs are unused in the same way that xc7 does.