### PR TITLE
interchange: Add pseudo-cell data for GND pseudo-pips

### DIFF
--- a/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/routing_graph.rs
@@ -56,6 +56,16 @@ impl IcTileType {
         self.pips.push(IcPip {
             src_wire: src_idx,
             dst_wire: dst_idx,
+            pseudo_cells: Vec::new(),
+        });
+    }
+    pub fn add_ppip(&mut self, src: IdString, dst: IdString, pseudo_cells: Vec<IcPseudoCell>) {
+        let src_idx = self.wire(src);
+        let dst_idx = self.wire(dst);
+        self.pips.push(IcPip {
+            src_wire: src_idx,
+            dst_wire: dst_idx,
+            pseudo_cells: pseudo_cells,
         });
     }
 }
@@ -72,9 +82,15 @@ impl IcWire {
     }
 }
 
+pub struct IcPseudoCell {
+    pub bel: IdString,
+    pub pins: Vec<IdString>,
+}
+
 pub struct IcPip {
     pub src_wire: usize,
     pub dst_wire: usize,
+    pub pseudo_cells: Vec<IcPseudoCell>,
 }
 
 // A tile instance
@@ -250,7 +266,13 @@ impl <'a> GraphBuilder<'a> {
                 let gnd_wire = self.ids.id("G:GND");
                 lt.wire(gnd_wire);
                 for i in 0..8 {
-                    lt.add_pip(gnd_wire, self.ids.id(&format!("JF{}", i)));
+                    lt.add_ppip(gnd_wire, self.ids.id(&format!("JF{}", i)),
+                        vec![
+                            IcPseudoCell {
+                                bel: self.ids.id(&format!("SLICE{}_LUT{}", &"ABCD"[(i/2)..(i/2)+1], i%2)),
+                                pins: vec![self.ids.id("F")],
+                            }
+                        ]);
                 }
             }
         }

--- a/libprjoxide/prjoxide/src/interchange_gen/writer.rs
+++ b/libprjoxide/prjoxide/src/interchange_gen/writer.rs
@@ -64,7 +64,19 @@ pub fn write(c: &Chip, db: &mut Database, ids: &mut IdStringDB, graph: &IcGraph,
                         p.set_directional(true);
                         p.set_buffered20(true);
                         p.set_buffered21(false);
-                        p.set_conventional(());
+                        if pip_data.pseudo_cells.is_empty() {
+                            p.set_conventional(());
+                        } else {
+                            let mut pcells = p.init_pseudo_cells(pip_data.pseudo_cells.len().try_into().unwrap());
+                            for (k, pc_data) in pip_data.pseudo_cells.iter().enumerate() {
+                                let mut pc = pcells.reborrow().get(k.try_into().unwrap());
+                                pc.set_bel(pc_data.bel.val().try_into().unwrap());
+                                let mut pc_pins = pc.init_pins(pc_data.pins.len().try_into().unwrap());
+                                for (m, pin_name) in pc_data.pins.iter().enumerate() {
+                                    pc_pins.set(m.try_into().unwrap(), pin_name.val().try_into().unwrap());
+                                }
+                            }
+                        }
                     }
                 }
                 {


### PR DESCRIPTION
Currently failing as nextpnr-fpga_interchange is assuming that all pseudo-pips have an input bel pin, this is currently under investigation.