### PR TITLE
Fix issue compiling when clap 3.0.0-beta.4  came out

### DIFF
--- a/libprjoxide/prjoxide/Cargo.toml
+++ b/libprjoxide/prjoxide/Cargo.toml
@@ -20,7 +20,8 @@ pulldown-cmark = "0.6.1"
 itertools = "0.8.2"
 rug = "1.6.0"
 log = "0.4.11"
-clap = "3.0.0-beta.2"
+clap = "<=3.0.0-beta.2"
+clap_derive = "<=3.0.0-beta.2"
 include_dir = "0.6.0"
 capnp = {version = "0.14", optional = true }
 flate2 = {version = "1.0", optional = true }


### PR DESCRIPTION
With latest clap (3.0.0-beta.4) there are issues compiling, have seen reports of same error on some other projects, guess enabling unstable feature is also option, but playing safe here.

```
   Compiling clap_derive v3.0.0-beta.4
   Compiling include_dir v0.6.2
   Compiling clap v3.0.0-beta.4
error[E0658]: arbitrary expressions in key-value attributes are unstable
 --> /tmp/linux-x64/registry/src/github.com-1ecc6299db9ec823/clap-3.0.0-beta.4/src/lib.rs:8:10
  |
8 | #![doc = include_str!("../README.md")]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #78835 <https://github.com/rust-lang/rust/issues/78835> for more information

   Compiling multimap v0.8.3
error[E0658]: use of unstable library feature 'osstring_ascii'
   --> /tmp/linux-x64/registry/src/github.com-1ecc6299db9ec823/clap-3.0.0-beta.4/src/parse/matches/matched_arg.rs:130:19
    |
130 |                 v.eq_ignore_ascii_case(val)
    |                   ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #70516 <https://github.com/rust-lang/rust/issues/70516> for more information

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0658`.
error: could not compile `clap`

```