### PR TITLE
Timing fuzzer hotfix

### DIFF
--- a/timing/fuzzers/LIFCL/05-clock/gen_clk.py
+++ b/timing/fuzzers/LIFCL/05-clock/gen_clk.py
@@ -125,7 +125,7 @@ for i in range(N):
     print('    always @(posedge {clk}) r[{i} + 1] <= r[{i}];'.format(clk=clkwire, i=i))
 
 for pll in used_plls:
-    print()
+    print("")
     for sig in pll_pins:
         print('    wire {}_{};'.format(pll, sig))
     print('    (* LOC="{}" *)'.format(pll))


### PR DESCRIPTION
When one's `python` pointed to a Python2 interpreter the fuzzer failed silently by writing literally `()` to Verilog code which caused syntax error.