### PR TITLE
Fix DCCs bel placement for top and bottom mux

### DIFF
--- a/libprjoxide/prjoxide/src/bels.rs
+++ b/libprjoxide/prjoxide/src/bels.rs
@@ -819,6 +819,19 @@ pub fn get_bel_tiles(chip: &Chip, tile: &Tile, bel: &Bel) -> Vec<String> {
                 _ => panic!("bad DSP tile {}", &tile.tiletype)
             }
         }
+        "DCC" => match &bel.name[..] {
+            "DCC_T" => match bel.z {
+                0..=7  => vec![tn],
+                8..=15 => vec![rel_tile_prefix(1, 0, "TMID_1")],
+                _ => panic!("bad DCC_T tile {}", &tile.tiletype)
+            }
+            "DCC_B" => match bel.z {
+                0..=8  => vec![tn],
+                9..=17 => vec![rel_tile(1, 0, "BMID_1_ECLK_2")],
+                _ => panic!("bad DCC_B tile {}", &tile.tiletype)
+            }
+            _ => vec![tn]
+        }
         _ => vec![tn]
     }
 }


### PR DESCRIPTION
Split top and bottom DCCs to correct tiles.
Signed-off-by: Maciej Dudek <mdudek@antmicro.com>