### PR TITLE
prjoxide: update clap

### DIFF
--- a/libprjoxide/prjoxide/Cargo.toml
+++ b/libprjoxide/prjoxide/Cargo.toml
@@ -20,8 +20,7 @@ pulldown-cmark = "0.6.1"
 itertools = "0.8.2"
 num-bigint = "0.4.0"
 log = "0.4.11"
-clap = "<=3.0.0-beta.2"
-clap_derive = "<=3.0.0-beta.2"
+clap = { version = "3.1", features = ["derive"] }
 include_dir = "0.6.0"
 capnp = {version = "0.14", optional = true }
 flate2 = {version = "1.0", optional = true }

--- a/libprjoxide/prjoxide/src/bin/prjoxide.rs
+++ b/libprjoxide/prjoxide/src/bin/prjoxide.rs
@@ -1,4 +1,4 @@
-use clap::Clap;
+use clap::Parser;
 
 use prjoxide::bba::bbafile::*;
 use prjoxide::bba::bbastruct::*;
@@ -20,33 +20,34 @@ use include_dir::{include_dir, Dir};
 
 const DATABASE_DIR: Dir = include_dir!("../../database");
 
-#[derive(Clap)]
+#[derive(Parser)]
 #[clap(version = "0.1", author = "gatecat <gatecat@ds0.me>")]
 struct Opts {
     #[clap(subcommand)]
     subcmd: SubCommand,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 enum SubCommand {
-    #[clap(about = "pack FASM into a bitstream")]
+    /// pack FASM into a bitstream.
     Pack(Pack),
-    #[clap(about = "unpack a bitstream into FASM")]
+    /// unpack a bitstream into FASM.
     Unpack(Unpack),
-    #[clap(about = "export a BBA file for the nextpnr build")]
+    /// export a BBA file for the nextpnr build.
     BBAExport(BBAExport),
     #[cfg(feature = "interchange")]
-    #[clap(about = "export a FPGA interchange file (not yet implemented)")]
+    /// export a FPGA interchange file (not yet implemented).
     InterchangeExport(InterchangeExport),
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Pack {
-    #[clap(long, about = "create background programmable bitstream (advanced)")]
+    /// create background programmable bitstream (advanced).
+    #[clap(long)]
     background: bool,
-    #[clap(about = "input FASM file")]
+    /// input FASM file.
     fasm: String,
-    #[clap(about = "output bitstream")]
+    /// output bitstream.
     bitstream: String,
 
 }
@@ -68,11 +69,11 @@ impl Pack {
     }
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct Unpack {
-    #[clap(about = "input bitstream")]
+    /// input bitstream.
     bitstream: String,
-    #[clap(about = "output FASM file")]
+    /// output FASM file.
     fasm: String,
 }
 
@@ -106,13 +107,13 @@ impl Unpack {
     }
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 struct BBAExport {
-    #[clap(about = "device family name")]
+    /// device family name.
     family: String,
-    #[clap(about = "path to nextpnr constids.inc")]
+    /// path to nextpnr constids.inc.
     constids: String,
-    #[clap(about = "path to output bba file")]
+    /// path to output bba file.
     bba: String,
 }
 
@@ -182,12 +183,12 @@ impl BBAExport {
     }
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 #[cfg(feature = "interchange")]
 struct InterchangeExport {
-    #[clap(about = "device name")]
+    /// device name.
     device: String,
-    #[clap(about = "path to output interchange file")]
+    /// path to output interchange file.
     interchange: String,
 }
 


### PR DESCRIPTION
Clap was fixed to `<=3.0.0-beta.2` in #12. Upon further investigation, `beta.4` was functioning as intended; it simply bumped clap's MSRV to 1.54 (see clap-rs/clap#2741).

Clap 3.1 supports Rust as early as 1.54. Upgrade to that (with a few fixes for a rename that happened in `3.0.0-beta.5`), since it's been out for well over a year now.