### PR TITLE
Add LIFCL-33U (CrossLinkU-NX) support

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -34,6 +34,22 @@
                         "": {"idcode": 823070787}
                     }
                 },
+                "LIFCL-33U": {
+                    "packages": ["CABGA196", "CSFBGA104"],
+                    "idcode": 17805379,
+                    "frames": 5344,
+                    "bits_per_frame": 1003,
+                    "pad_bits_after_frame": 0,
+                    "pad_bits_before_frame": 0,
+                    "frame_ecc_bits": 14,
+                    "max_row" : 30,
+                    "max_col" : 41,
+                    "col_bias" : 0,
+                    "fuzz": false,
+                    "variants": {
+                        "": {"idcode": 17805379}
+                    }
+                },
                 "LIFCL-17": {
                     "packages": ["QFN72", "csfBGA121", "caBGA256"],
                     "idcode": 17760323,

--- a/fuzzers/LIFCL/shared/empty_33u.v
+++ b/fuzzers/LIFCL/shared/empty_33u.v
@@ -1,0 +1,10 @@
+(* \db:architecture ="LIFCL", \db:device ="LIFCL-33U", \db:package ="FCCSP104", \db:speed ="8_High-Performance_1.0V", \db:timestamp =1576073342, \db:view ="physical" *)
+module top (
+
+);
+	(* \xref:LOG ="q_c@0@9"${arcs_attr} *)
+	wire q;
+
+	(* \dm:cellmodel_primitives ="REG0=reg", \dm:primitive ="SLICE", \dm:programming ="MODE:LOGIC Q0:Q0 ", \dm:site ="R2C2A" *) 
+	SLICE SLICE_I ( .A0(q), .Q0(q) );
+endmodule

--- a/fuzzers/LIFCL/shared/route_33u.v
+++ b/fuzzers/LIFCL/shared/route_33u.v
@@ -1,0 +1,10 @@
+(* \db:architecture ="LIFCL", \db:device ="LIFCL-33U", \db:package ="FCCSP104", \db:speed ="8_High-Performance_1.0V", \db:timestamp =1576073342, \db:view ="physical" *)
+module top (
+
+);
+	(* \xref:LOG ="q_c@0@9"${arcs_attr} *)
+	wire q;
+
+	(* \dm:cellmodel_primitives ="REG0=reg", \dm:primitive ="SLICE", \dm:programming ="MODE:LOGIC Q0:Q0 ", \dm:site ="R10C10A" *) 
+	SLICE SLICE_I ( .A0(q), .Q0(q) );
+endmodule

--- a/libprjoxide/prjoxide/src/bels.rs
+++ b/libprjoxide/prjoxide/src/bels.rs
@@ -774,6 +774,7 @@ pub fn get_tile_bels(tiletype: &str, tiledata: &TileBitsDatabase) -> Vec<Bel> {
         "GPLL_LLC_15K" => vec![Bel::make_pll_core("PLL_LLC", &tiledata, 0, -1, true)],
         "GPLL_LRC_15K" => vec![Bel::make_pll_core("PLL_LRC", &tiledata, 0, -1, true)],
         "LRAM_0" => vec![Bel::make_lram_core("LRAM0", &tiledata, -1, -5)],
+        "LRAM_0_33U" => vec![Bel::make_lram_core("LRAM0", &tiledata, -1, 0)],
         "LRAM_1" => vec![Bel::make_lram_core("LRAM1", &tiledata, -1, -1)],
 
         "LRAM_0_15K" => vec![Bel::make_lram_core("LRAM0", &tiledata, -1, 0)],
@@ -861,7 +862,7 @@ pub fn get_bel_tiles(chip: &Chip, tile: &Tile, bel: &Bel) -> Vec<String> {
         },
         "CONFIG_MULTIBOOT_CORE" | "CONFIG_LMMI_CORE" | "CONFIG_CLKRST_CORE" => match tt {
             "EFB_0" => {
-                vec![tn, rel_tile_prefix(2, 0, "EFB_1_OSC"), rel_tile_prefix(4, 0, "EFB_2"), rel_tile_prefix(6, 0, "I2C_EFB_3")]
+                vec![tn, rel_tile_prefix(2, 0, "EFB_1"), rel_tile_prefix(4, 0, "EFB_2"), rel_tile_prefix(6, 0, "I2C_EFB_3")]
             },
             _ => { // default: -17 case
                 vec![tn]

--- a/libprjoxide/prjoxide/src/bin/prjoxide.rs
+++ b/libprjoxide/prjoxide/src/bin/prjoxide.rs
@@ -142,7 +142,7 @@ impl BBAExport {
         }
 
         let speed_grades = vec!["4", "5", "6", "10", "11", "12", "M"];
-        let devices = vec!["LIFCL-40", "LFD2NX-40", "LIFCL-17"];
+        let devices = vec!["LIFCL-40", "LFD2NX-40", "LIFCL-17", "LIFCL-33U"];
         let mut db = Database::new_builtin(DATABASE_DIR);
 
         let tts = TileTypes::new(&mut db, &mut ids, "LIFCL", &devices);

--- a/libprjoxide/prjoxide/src/chip.rs
+++ b/libprjoxide/prjoxide/src/chip.rs
@@ -354,6 +354,8 @@ impl Chip {
             format!("SG{}", &long_name[3..])
         } else if long_name.starts_with("WLCSP") {
             format!("UWG{}", &long_name[5..])
+        } else if long_name.starts_with("FCCSP") {
+            format!("CTG{}", &long_name[5..])
         } else {
             panic!("unknown package name {}", &long_name);
         }

--- a/radiant.sh
+++ b/radiant.sh
@@ -27,6 +27,13 @@ case "${PART}" in
 		LSE_ARCH="lifcl"
 		SPEED_GRADE="${SPEED_GRADE:-7_High-Performance_1.0V}"
 		;;
+	LIFCL-33U)
+		PACKAGE="${DEV_PACKAGE:-FCCSP104}"
+		DEVICE="LIFCL-33U"
+		LSE_ARCH="lifcl"
+		SPEED_GRADE="${SPEED_GRADE:-8_High-Performance_1.0V}"
+		;;
+
 	LIFCL-40)
 		PACKAGE="${DEV_PACKAGE:-CABGA400}"
 		DEVICE="LIFCL-40"

--- a/tools/extract_tilegrid.py
+++ b/tools/extract_tilegrid.py
@@ -59,6 +59,10 @@ tap_frame_to_col_17 = {
     28: 50,
     34: 62
 }
+tap_frame_to_col_33u = {
+    16: 14,
+    22: 38,
+}
 
 def get_tf2c(dev):
     if dev == "LFCPNX-100":
@@ -67,6 +71,8 @@ def get_tf2c(dev):
         return tap_frame_to_col_40
     elif dev == "LIFCL-17":
         return tap_frame_to_col_17
+    elif dev == "LIFCL-33U":
+        return tap_frame_to_col_33u
     else:
         assert False
 


### PR DESCRIPTION
## Summary

- Add LIFCL-33U device support (CrossLinkU-NX, FCCSP104/CABGA196 packages)
- Add FCCSP→CTG package name mapping in chip.rs
- Add LRAM_0_33U bel variant with correct CIB offset
- Fix EFB_1 tile prefix matching to work for both LIFCL-40 (EFB_1_OSC) and LIFCL-33U (EFB_1)
- Add LIFCL-33U to BBA export, radiant.sh, and tilegrid extraction
- Add fuzzer templates (empty_33u.v, route_33u.v)

Companion database PR: https://github.com/gatecat/prjoxide-db/pull/3

### Hardware verification
Full open-source toolchain verified on CrossLinkU-NX Evaluation Board (LIFCL-33U-EVN Rev B.1):
- yosys `synth_nexus` → nextpnr-nexus → prjoxide pack → JTAG program
- Clock routing through CMUX → SPINE → TAP → BRANCH path confirmed working

## Test plan
- [x] Blink design end-to-end on LIFCL-33U-EVN hardware
- [x] prjoxide pack produces valid bitstream
- [x] prjoxide unpack round-trips correctly
- [ ] BBA export produces valid chipdb for nextpnr-nexus

🤖 Generated with [Claude Code](https://claude.com/claude-code)